### PR TITLE
feat(keymap): swap curly braces and square brackets positions

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -27,8 +27,8 @@
             bindings = <
 &trans  &trans  &trans  &trans  &trans  &trans                    &trans          &trans     &trans            &trans             &trans           &kp DELETE
 &trans  &trans  &trans  &trans  &trans  &trans                    &trans          &trans     &trans            &trans             &kp PRINTSCREEN  &trans
-&trans  &trans  &trans  &trans  &trans  &trans                    &kp MINUS       &kp EQUAL  &kp LEFT_BRACE    &kp RIGHT_BRACE    &kp PIPE         &trans
-&trans  &trans  &trans  &trans  &trans  &trans  &trans    &trans  &kp UNDERSCORE  &kp PLUS   &kp LEFT_BRACKET  &kp RIGHT_BRACKET  &kp BACKSLASH    &trans
+&trans  &trans  &trans  &trans  &trans  &trans                    &kp MINUS       &kp EQUAL  &kp LEFT_BRACKET  &kp RIGHT_BRACKET  &kp PIPE         &trans
+&trans  &trans  &trans  &trans  &trans  &trans  &trans    &trans  &kp UNDERSCORE  &kp PLUS   &kp LEFT_BRACE    &kp RIGHT_BRACE    &kp BACKSLASH    &trans
                         &trans  &trans  &trans  &trans    &trans  &trans          &trans     &trans
             >;
         };


### PR DESCRIPTION
Change key bindings to swap {} and [] positions in the Extra layer:
- [ ] now on positions where { } were previously
- { } now on positions where [ ] were previously